### PR TITLE
Update BP name to avoid future conflicts

### DIFF
--- a/SolastaDruidClass/DruidClass.cs
+++ b/SolastaDruidClass/DruidClass.cs
@@ -10,7 +10,7 @@ namespace SolastaDruidClass
 {
     internal class DruidClassBuilder : CharacterClassDefinitionBuilder
     {
-        const string DruidClassName = "Druid";
+        const string DruidClassName = "DHDruid";
         const string DruidClassGuid = "a2112af0-636f-4b72-acdc-07c921bcea6d";
         const string DruidClassSubclassesGuid = "46ae0591-296d-4f6c-80b0-4e198c999076";
 


### PR DESCRIPTION
. TA might implement Druid in the future. It's a good practice to prefix all your GUIDs with some namespace to avoid bumping on TA future blueprints. Added DH as a prefix to the class name but you need to do on any new Blueprint you create.